### PR TITLE
Extend controllers with handy view renderers

### DIFF
--- a/lib/generators/spine/new/new_generator.rb
+++ b/lib/generators/spine/new/new_generator.rb
@@ -47,7 +47,9 @@ module Spine
         end
        
         def add_spine_app_to_application
-          append_file "app/assets/javascripts/application.js", "//= require #{app_name}\n"
+          inject_into_file "app/assets/javascripts/application.js", :before => "//= require_tree" do
+            "//= require #{app_name}/index\n"
+          end
         end
       end
 

--- a/lib/generators/spine/new/templates/index.coffee.erb
+++ b/lib/generators/spine/new/templates/index.coffee.erb
@@ -1,4 +1,4 @@
-#= require json2
+t#= require json2
 #= require jquery
 #= require spine
 #= require spine/manager
@@ -23,3 +23,20 @@ class <%= app_class %> extends Spine.Controller
     Spine.Route.setup()
 
 window.<%= app_class %> = <%= app_class %>
+
+
+# Helpers / shortcuts for controllers
+Spine.Controller.include
+  # instead of JST['app/views/posts/show'] just write
+  # @view('posts/show') => function that generates HTML
+  view: (name) -> JST["<%= app_name %>/views/#{name}"]
+
+  # @renderView('posts/show', post) => html string
+  renderView: (name, data) -> @view(name)(data)
+
+  # @htmlFor('show', post) => html string
+  htmlFor: (subViewName, data) ->
+    protoString = @constructor.toString().match(/^function ([^\(]+)/)[1] # Blogs
+    areaName = protoString.toLowerCase() # blogs
+    @renderView "#{areaName}/#{subViewName}", data # @htmlFor "blogs/show", data
+

--- a/lib/generators/spine/new/templates/index.coffee.erb
+++ b/lib/generators/spine/new/templates/index.coffee.erb
@@ -6,7 +6,6 @@
 #= require spine/route
 #= require spine/rails
 
-#= require_tree ./lib
 #= require_self
 #= require_tree ./models
 #= require_tree ./controllers


### PR DESCRIPTION
@maccman We've already discussed it, but still. Can you please reconsider adding these helpers.

Without those we will have to write:

``` coffee
render: ->
  @el.html JST['app/views/posts/show'](post)
```

instead of:

``` coffee
render: ->
  @el.html @htmlFor 'show', post
```

I really think that it makes a huge difference.
