### PR TITLE
Generate Jasmin specs with Model and Controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Use the top-level level `index.coffee` file to setup namespacing and initial con
 
 ## Generators
 
-spine-rails provides three simple generators to help you get started:
+spine-rails provides three simple generators to help you get started.
+
+It will also create Jasmine specs for Models and Controllers if [jasmine](https://github.com/pivotal/jasmine) gem is available.
 
 ### Model
 

--- a/lib/generators/spine/controller/controller_generator.rb
+++ b/lib/generators/spine/controller/controller_generator.rb
@@ -13,6 +13,7 @@ module Spine
           app_name, "controllers", 
           class_path, file_name.pluralize + ".coffee"
         )
+        generate_jasmine_spec object_name, "controllers"
       end
     end
   end

--- a/lib/generators/spine/model/model_generator.rb
+++ b/lib/generators/spine/model/model_generator.rb
@@ -11,6 +11,7 @@ module Spine
 
       def create_model
         template "model.coffee.erb", "app/assets/javascripts/#{app_name}/models/#{file_name}.coffee"
+        generate_jasmine_spec object_name, "models"
       end
     end
   end

--- a/lib/spine/generators.rb
+++ b/lib/spine/generators.rb
@@ -3,6 +3,10 @@ module Spine
     class Base < ::Rails::Generators::NamedBase
       class_option :app, :type => :string, :default => "app", :desc => "app name"
       
+
+      # These are just helpers, and should not be executed. Thus must be protected.
+      protected
+
       def class_name
         (class_path + [file_name]).map!{ |m| m.camelize }.join('')
       end
@@ -13,6 +17,25 @@ module Spine
       
       def app_class
         app_name.camelize
+      end
+
+      def object_name
+        file_name.camelize
+      end
+
+      def generate_jasmine_spec subject, path
+        return false unless defined?(::Jasmine)
+        variable_name = "#{subject.underscore}"
+
+        # TODO: Consider moving this into a template
+        create_file "spec/javascripts/#{app_name}/#{path}/#{variable_name}_spec.coffee", <<-SPEC
+describe "#{subject}", ->
+  #{variable_name} = null
+  beforeEach -> # init #{variable_name} here
+    
+  it "should be tested", ->
+    expect(#{variable_name}).toBeTruthy()
+SPEC
       end
     end
   end


### PR DESCRIPTION
This will generate Jasmine specs with Model and Controllers when Jasmine gem is available.
Otherwise, it will behave as previously.
